### PR TITLE
C++11 compliancy: removed tr1 instances

### DIFF
--- a/basic/std.h
+++ b/basic/std.h
@@ -15,11 +15,10 @@
 #include <vector>
 #include <string>
 #include <queue>
-#include <tr1/unordered_map>
-#include <tr1/unordered_set>
+#include <unordered_map>
+#include <unordered_set>
 
 using namespace std;
-using namespace std::tr1;
 
 ////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Changed includes of <tr1/xyz> to <xyz>. Code compiles without complaint on C++11 compilers like clang.
