### PR TITLE
Enable >= 2^31 tokens in input data

### DIFF
--- a/basic/lisp.cc
+++ b/basic/lisp.cc
@@ -9,7 +9,7 @@ void LispNode::destroy() {
   }
 }
 
-void LispNode::print(int ind) const {
+void LispNode::print(intIndex ind) const {
   cout << Indent(ind) << (value.empty() ? "(empty)" : value) << endl;
   forvec(_, LispNode *, subnode, children)
     subnode->print(ind+1);
@@ -82,7 +82,7 @@ bool LispTree::read_token(istream &in, string &s) {
   return true;
 }
 
-LispNode *LispTree::read_node(const vector<string> &tokens, int &i) {
+LispNode *LispTree::read_node(const vector<string> &tokens, intIndex &i) {
   LispNode *node = new LispNode();
   assert(i < len(tokens));
 
@@ -118,7 +118,7 @@ void LispTree::read(const char *file) {
   while(read_token(in, token)) {
     tokens.push_back(token);
   }
-  int i = 0;
+  intIndex i = 0;
   root = read_node(tokens, i);
   assert(i == len(tokens));
 }

--- a/basic/lisp.h
+++ b/basic/lisp.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <string>
+#include "std.h"
 
 using namespace std;
 
@@ -10,7 +11,7 @@ using namespace std;
 
 struct LispNode {
   void destroy();
-  void print(int ind) const;
+  void print(intIndex ind) const;
 
   string value;
   vector<LispNode *> children;
@@ -23,7 +24,7 @@ struct LispTree {
   ~LispTree();
 
   bool read_token(istream &in, string &s);
-  LispNode *read_node(const vector<string> &tokens, int &i);
+  LispNode *read_node(const vector<string> &tokens, intIndex &i);
   void read(const char *file);
   void print() const;
 

--- a/basic/mem-tracker.cc
+++ b/basic/mem-tracker.cc
@@ -8,7 +8,7 @@
 
 ////////////////////////////////////////////////////////////
 
-int MemTracker::compute_mem_usage(const MemRecord &r) {
+long MemTracker::compute_mem_usage(const MemRecord &r) {
   switch(r.type) {
     list_types(define_case);
     default: assert(0);
@@ -16,8 +16,8 @@ int MemTracker::compute_mem_usage(const MemRecord &r) {
   return 0;
 }
 
-int MemTracker::compute_mem_usage() {
-  int total_mem = 0;
+long MemTracker::compute_mem_usage() {
+  long total_mem = 0;
   forvec(_, MemRecord &, r, records) {
     if(r.type != T_RAWNUMBER) r.mem = compute_mem_usage(r);
     total_mem += r.mem;
@@ -32,7 +32,7 @@ static bool record_less_than(const MemRecord &r1, const MemRecord &r2) {
 void MemTracker::report_mem_usage() {
   track("report_mem_usage()", "", true);
 
-  int total_mem = compute_mem_usage();
+  long total_mem = compute_mem_usage();
 
   sort(records.begin(), records.end(), record_less_than);
 

--- a/basic/mem-tracker.h
+++ b/basic/mem-tracker.h
@@ -39,14 +39,14 @@
 enum MemType { T_RAWNUMBER, list_types(prefix_t) };
 
 struct MemRecord {
-  MemRecord(const char *name, int mem) :
+  MemRecord(const char *name, long mem) :
     name(name), type(T_RAWNUMBER), data(NULL), mem(mem) { }
   MemRecord(const char *name, MemType type, const void *data) :
     name(name), type(type), data(data), mem(0) { }
   string name;
   MemType type;
   const void *data;
-  int mem;
+  long mem;
 };
 
 // Track amount of memory used.
@@ -56,12 +56,12 @@ public:
 
   list_types(define_add)
 
-  void add(const char *name, int mem) {
+  void add(const char *name, long mem) {
     records.push_back(MemRecord(name, mem));
   }
 
-  int compute_mem_usage(const MemRecord &r);
-  int compute_mem_usage();
+  long compute_mem_usage(const MemRecord &r);
+  long compute_mem_usage();
   void report_mem_usage();
 
 private:
@@ -73,8 +73,8 @@ extern MemTracker mem_tracker;
 ////////////////////////////////////////////////////////////
 // Various mem_usage() functions on various data types.
 
-template<class T> int mem_usage(const vector< vector< vector< vector<T> > > > &mat) { // matrix
-  int mem = 0;
+template<class T> long mem_usage(const vector< vector< vector< vector<T> > > > &mat) { // matrix
+  long mem = 0;
   foridx(i, len(mat)) {
     foridx(j, len(mat[i])) {
       foridx(k, len(mat[i][j]))
@@ -87,8 +87,8 @@ template<class T> int mem_usage(const vector< vector< vector< vector<T> > > > &m
   return mem;
 }
 
-template<class T> int mem_usage(const vector< vector< vector<T> > > &mat) { // matrix
-  int mem = 0;
+template<class T> long mem_usage(const vector< vector< vector<T> > > &mat) { // matrix
+  long mem = 0;
   foridx(i, len(mat)) {
     foridx(j, len(mat[i]))
       mem += len(mat[i][j]) * sizeof(T);
@@ -98,32 +98,32 @@ template<class T> int mem_usage(const vector< vector< vector<T> > > &mat) { // m
   return mem;
 }
 
-template<class T> int mem_usage(const vector< vector<T> > &mat) { // matrix
-  int mem = 0;
+template<class T> long mem_usage(const vector< vector<T> > &mat) { // matrix
+  long mem = 0;
   foridx(i, len(mat))
     mem += len(mat[i]) * sizeof(T);
   mem += len(mat) * sizeof(vector<T>);
   return mem;
 }
 
-template<class T> int mem_usage(const vector<T> &vec) { // vector
+template<class T> long mem_usage(const vector<T> &vec) { // vector
   return len(vec) * sizeof(T);
 }
 
-template<class T> int mem_usage(const unordered_set<T> &set) { // hash_set
-  return (int)set.bucket_count()*4 + len(set)*(sizeof(T)+sizeof(void *));
+template<class T> long mem_usage(const unordered_set<T> &set) { // hash_set
+  return (long)set.bucket_count()*4 + len(set)*(sizeof(T)+sizeof(void *));
 }
 
-template<class Tx, class Ty, class Hf, class Eq> int mem_usage(const unordered_map<Tx, Ty, Hf, Eq> &map) { // hash_map
-  return (int)map.bucket_count()*4 + len(map)*(sizeof(Tx)+sizeof(Ty)+sizeof(void *));
+template<class Tx, class Ty, class Hf, class Eq> long mem_usage(const unordered_map<Tx, Ty, Hf, Eq> &map) { // hash_map
+  return (long)map.bucket_count()*4 + len(map)*(sizeof(Tx)+sizeof(Ty)+sizeof(void *));
 }
 
-inline int mem_usage(const UnionSet &u) { // UnionSet
+inline long mem_usage(const UnionSet &u) { // UnionSet
   return mem_usage(u.parent);
 }
 
-inline int mem_usage(const StrDB &db) { // StrDB
-  int mem = mem_usage(db.s2i) + mem_usage(db.i2s);
+inline long mem_usage(const StrDB &db) { // StrDB
+  long mem = mem_usage(db.s2i) + mem_usage(db.i2s);
   foridx(i, len(db))
     mem += (strlen(db[i])+1) * sizeof(char);
   return mem;

--- a/basic/mem.h
+++ b/basic/mem.h
@@ -2,9 +2,9 @@
 #define __MEM_H__
 
 // Takes memory is in bytes and formats it nicely
-struct Mem { Mem(int mem) : mem(mem) { } int mem; };
+struct Mem { Mem(long mem) : mem(mem) { } long mem; };
 inline ostream &operator<<(ostream &out, const Mem &m) {
-  unsigned int mem = m.mem;
+  unsigned long mem = m.mem;
   if(mem < 1024)           out << mem;
   else if(mem < 1024*1024) out << mem/1024 << 'K';
   else                     out << mem/(1024*1024) << 'M';

--- a/basic/multi-ostream.cc
+++ b/basic/multi-ostream.cc
@@ -15,7 +15,7 @@ using namespace std;
 
 multi_buf::~multi_buf() {
   flush();
-  for(int i = 0; i < (int)infos.size(); i++)
+  for(size_t i = 0; i < infos.size(); i++)
     infos[i].destroy();
 }
 
@@ -24,7 +24,7 @@ void multi_buf::add(ostream *out, bool own, bool hard) {
 }
 
 void multi_buf::flush() {
-  for(int i = 0; i < (int)infos.size(); i++) {
+  for(size_t i = 0; i < infos.size(); i++) {
     ostream_info &info = infos[i];
     info.out->write(buf, buf_i); 
     info.out->flush();
@@ -33,7 +33,7 @@ void multi_buf::flush() {
 }
 
 void multi_buf::hard_flush() {
-  for(int i = 0; i < (int)infos.size(); i++) {
+  for(size_t i = 0; i < infos.size(); i++) {
     ostream_info &info = infos[i];
     info.out->write(buf, buf_i); 
     if(info.hard)

--- a/basic/std.cc
+++ b/basic/std.cc
@@ -18,7 +18,7 @@ string hostname() {
 }
 
 // Return the amount of memory (kB) used by this process
-int mem_usage() {
+long mem_usage() {
   ifstream in("/proc/self/status");
   if(!in) return 0;
   char buf[1024];
@@ -28,8 +28,8 @@ int mem_usage() {
     if(strncmp(buf, key, strlen(key)) != 0) continue;
     char *s = strchr(buf, ':');
     if(!s) return 0;
-    int x;
-    sscanf(s+1, "%d", &x);
+    long x;
+    sscanf(s+1, "%ld", &x);
     return x;
   }
   return -1;

--- a/basic/std.h
+++ b/basic/std.h
@@ -20,14 +20,19 @@
 
 using namespace std;
 
+typedef long intIndex;
+
+#define INT_SIZED(x)    assert((x) < 2147483648L)
+
 ////////////////////////////////////////////////////////////
 
-#define len(vec) (int)(vec).size()
+#define len(vec) (intIndex)(vec).size()
 #define sq(x) ((x)*(x))
 
 // For loop sugar.  This is such a hack!
-#define foridx(i, n)                  for(int i = 0; i < n; i++)
-#define forvec(i, tx, x, vec)         for(int i = 0, _##i = 0; i < len(vec); i++) \
+#define foridx(i, n)                  for(intIndex i = 0; i < n; i++)
+#define forsidx(i, n)                 for(int i = 0; i < n; i++)
+#define forvec(i, tx, x, vec)         for(intIndex i = 0, _##i = 0; i < len(vec); i++) \
                                       for(tx x = (vec)[i]; i == _##i; _##i++)
 #define formap(tx, x, ty, y, t, map)  forstl(t, _##x##y, map) _mapvars(tx, x, ty, y)
 #define forcmap(tx, x, ty, y, t, map) forcstl(t, _##x##y, map) _mapvars(tx, x, ty, y)
@@ -39,10 +44,10 @@ using namespace std;
 ////////////////////////////////////////////////////////////
 // Generate random numbers.
 
-inline int mrand(int a)        { return rand() % a; }
-inline int mrand(int a, int b) { return rand() % (b-a) + a; }
+inline intIndex mrand(intIndex a)        { return rand() % a; }
+inline intIndex mrand(intIndex a, intIndex b) { return rand() % (b-a) + a; }
 inline double rand_double() {
-  static const int BASE = 100000;
+  static const intIndex BASE = 100000;
   return (double)(rand()%BASE)/BASE;
 }
 
@@ -57,7 +62,7 @@ inline bool fgt(double u, double v) { return u - TOL > v; }
 // Comparing floating point numbers.
 inline bool feq(double u, double v, double tol = TOL) { return fabs(u-v) < tol; }
 
-template <class T> inline int sign(T u) {
+template <class T> inline intIndex sign(T u) {
   if(u < 0) return -1;
   if(u > 0) return 1;
   return 0;
@@ -96,7 +101,7 @@ template<class T> inline void _assert_eq(const T &u, const T &v, const char *us,
 string now();
 string hostname();
 int cpu_speed_mhz();
-int mem_usage(); // in kB
+long mem_usage(); // in kB
 
 bool create_file(const char *file);
 bool file_exists(const char *file);

--- a/basic/stl-utils.h
+++ b/basic/stl-utils.h
@@ -135,10 +135,10 @@ template<class T> inline int vector_min(const vector<T> &vec) {
 }
 
 // Returns the index of the maximum element in vec.
-template<class T> inline int vector_index_max(const vector<T> &vec) {
+template<class T> inline intIndex vector_index_max(const vector<T> &vec) {
   T max = vec[0];
   int best_i = 0;
-  foridx(i, len(vec)) {
+  forsidx(i, len(vec)) {
     if(vec[i] > max) {
       max = vec[i];
       best_i = i;
@@ -155,8 +155,8 @@ template<class T> inline int vector_max(const vector<T> &vec) {
 template<class T> inline IntPair matrix_index_max(const vector< vector<T> > &mat) {
   T max = mat[0][0];
   IntPair best_ij = IntPair(0, 0);
-  foridx(i, len(mat)) {
-    foridx(j, len(mat[i])) {
+  forsidx(i, len(mat)) {
+    forsidx(j, len(mat[i])) {
       if(mat[i][j] > max) {
         max = mat[i][j];
         best_ij = IntPair(i, j);
@@ -190,8 +190,8 @@ template<class T> ostream &operator<<(ostream &out, const vector< vector<T> > &m
   return out;
 }
 
-template<class T> vector<T> subvector(const vector<T> &vec, int i, int j = -1) {
-  int N = len(vec);
+template<class T> vector<T> subvector(const vector<T> &vec, intIndex i, intIndex j = -1) {
+  intIndex N = len(vec);
   if(j < 0) j += N;
   if(j < i) j = i;
 

--- a/basic/strdb.h
+++ b/basic/strdb.h
@@ -22,7 +22,7 @@ struct StrDB {
   void write(ostream &out);
   void write(const char *file);
 
-  int size() const   { return len(i2s); }
+  intIndex size() const   { return len(i2s); }
   void clear()       { destroy_strings(); i2s.clear(); s2i.clear(); }
   void destroy()     { destroy_strings(); ::destroy(i2s); ::destroy(s2i); }
   void destroy_s2i() { ::destroy(s2i); }
@@ -53,7 +53,7 @@ struct IntPairIntDB {
   IntPair operator[](int i) const { return i2p[i]; }
   int operator[](const IntPair &p) { return lookup(p, true, -1); }
   int lookup(const IntPair &p, bool incorp_new, int default_i);
-  int size() const { return len(i2p); }
+  intIndex size() const { return len(i2p); }
 
   int read(istream &in, int N);
   void write(ostream &out);
@@ -69,7 +69,7 @@ struct IntVecIntDB {
   const IntVec &operator[](int i) const { return i2v[i]; }
   int operator[](const IntVec &v) { return lookup(v, true, -1); }
   int lookup(const IntVec &v, bool incorp_new, int default_i);
-  int size() const { return len(i2v); }
+  intIndex size() const { return len(i2v); }
 
   IntVecIntMap v2i;
   IntVecVec i2v;

--- a/wcluster.cc
+++ b/wcluster.cc
@@ -138,7 +138,7 @@ bool all_done = false;
 #define num_phrases(l) (len(phrases[l])/(l))
 
 int N; // number of phrases
-int T; // length of text
+intIndex T; // length of text
 
 // Output a phrase.
 struct Phrase { Phrase(int a) : a(a) { } int a; };
@@ -333,10 +333,10 @@ void read_text() {
   // Count the phrases that we care about so we can map them all to integers.
   track_block("Counting phrases", "", false) {
     phrases.resize(plen+1);
-    for(int l = 1; l <= plen; l++) {
+    for(intIndex l = 1; l <= plen; l++) {
       // Count.
       IntVecIntMap freqs; // phrase vector -> number of occurrences
-      for(int i = 0; i < T-l+1; i++) {
+      for(intIndex i = 0; i < T-l+1; i++) {
         IntVec a_vec = subvector(text, i, i+l);
         if(!is_good_phrase(a_vec)) continue;
         freqs[a_vec]++;
@@ -345,29 +345,31 @@ void read_text() {
       forcmap(const IntVec &, a_vec, int, count, IntVecIntMap, freqs) {
         if(count < min_occur) continue;
 
-        int a = len(phrase_freqs);
+        int a = (int)len(phrase_freqs);
         phrase_freqs.push_back(count);
         vec2phrase[a_vec] = a;
         forvec(_, int, w, a_vec) phrases[l].push_back(w);
       }
 
+      INT_SIZED(len(freqs));
       logs(len(freqs) << " distinct phrases of length " << l << ", keeping " << num_phrases(l) << " which occur at least " << min_occur << " times");
     }
   }
 
-  N = len(phrase_freqs); // number of phrases
+  INT_SIZED(len(phrase_freqs));
+  N = (int)len(phrase_freqs); // number of phrases
 
   track_block("Finding left/right phrases", "", false) {
     left_phrases.resize(N);
     right_phrases.resize(N);
-    for(int l = 1; l <= plen; l++) {
-      for(int i = 0; i < T-l+1; i++) {
+    for(intIndex l = 1; l <= plen; l++) {
+      for(intIndex i = 0; i < T-l+1; i++) {
         IntVec a_vec = subvector(text, i, i+l);
         if(!contains(vec2phrase, a_vec)) continue;
         int a = vec2phrase[a_vec];
 
         // Left
-        for(int ll = 1; ll <= plen && i-ll >= 0; ll++) {
+        for(intIndex ll = 1; ll <= plen && i-ll >= 0; ll++) {
           IntVec aa_vec = subvector(text, i-ll, i);
           if(!contains(vec2phrase, aa_vec)) continue;
           int aa = vec2phrase[aa_vec];
@@ -376,7 +378,7 @@ void read_text() {
         }
 
         // Right
-        for(int ll = 1; ll <= plen && i+l+ll <= T; ll++) {
+        for(intIndex ll = 1; ll <= plen && i+l+ll <= T; ll++) {
           IntVec aa_vec = subvector(text, i+l, i+l+ll);
           if(!contains(vec2phrase, aa_vec)) continue;
           int aa = vec2phrase[aa_vec];
@@ -391,7 +393,7 @@ void read_text() {
   if(!featvec_file.empty()) {
     ofstream out(featvec_file.c_str());
     out << N << ' ' << 2*N << endl;
-    foridx(a, N) {
+    forsidx(a, N) {
       IntIntMap phrase_counts;
       add_to_set(left_phrases[a], phrase_counts, 0);
       add_to_set(right_phrases[a], phrase_counts, N);
@@ -537,7 +539,7 @@ void create_initial_clusters() {
   track("create_initial_clusters()", "", true);
 
   freq_order_phrases.resize(N);
-  foridx(a, N) freq_order_phrases[a] = a;
+  forsidx(a, N) freq_order_phrases[a] = a;
 
   logs("Sorting " << N << " phrases by frequency");
   sort(freq_order_phrases.begin(), freq_order_phrases.end(), phrase_freq_greater);
@@ -551,7 +553,7 @@ void create_initial_clusters() {
   // Create the inital clusters.
   phrase2rep.Init(N); // Init union-set: each phrase starts out in its own cluster
   curr_minfo = 0.0;
-  foridx(s, initC) {
+  forsidx(s, initC) {
     int a = freq_order_phrases[s];
     put_cluster_in_slot(a, s);
 
@@ -599,7 +601,8 @@ void output_best_collocations() {
   FOR_SLOT(s) FOR_SLOT(t) {
     collocs.push_back(pair<double, IntPair>(q2[s][t], _(slot2cluster[s], slot2cluster[t])));
   }
-  ncollocs = min(ncollocs, len(collocs));
+  INT_SIZED(len(collocs));
+  ncollocs = min(ncollocs, (int)len(collocs));
   partial_sort(collocs.begin(), collocs.begin()+ncollocs, collocs.end(), greater< pair<double, IntPair> >());
 
   ofstream out(collocs_file.c_str());
@@ -697,7 +700,8 @@ void update_L2(int thread_id) {
     thread_start[thread_id].lock();
     if ( all_done ) break;  // mechanism to close the threads
 
-    int num_clusters = len(slot2cluster);
+    INT_SIZED(len(slot2cluster));
+    int num_clusters = (int)len(slot2cluster);
 
     if (the_job.is_type_a) {
       int s = the_job.s;
@@ -893,7 +897,7 @@ void compute_cluster_distribs() {
   IntIntMap count1; // cluster a -> number of times a appears
 
   // Compute cluster distributions
-  foridx(a, N) {
+  forsidx(a, N) {
     int ca = phrase2cluster(a);
     forvec(_, int, b, right_phrases[a]) {
       int cb = phrase2cluster(b);
@@ -906,7 +910,7 @@ void compute_cluster_distribs() {
   // For each word (phrase), compute its distribution
   kl_map[0].resize(N);
   kl_map[1].resize(N);
-  foridx(a, N) {
+  forsidx(a, N) {
     int ca = phrase2cluster(a);
     IntIntMap a_count2;
     int a_count1 = 0;
@@ -930,6 +934,7 @@ void compute_cluster_distribs() {
       a_count1++;
     }
     kl = kl_map[1][a] = kl_divergence(a_count2, a_count1, count2, count1, ca, true);
+    (void)kl;
     //logs("Right-KL(" << Phrase(a) << " | " << Cluster(ca) << ") = " << kl);
   }
 }
@@ -958,7 +963,7 @@ void convert_paths_to_map() {
 
   // Create the inital clusters.
   phrase2rep.Init(N); // Init union-set: each phrase starts out in its own cluster
-  foridx(a, N) {
+  forsidx(a, N) {
     rep2cluster[a] = a;
     cluster2rep[a] = a;
   }


### PR DESCRIPTION
The vector of tokens in the input internally has large enough indices to handle more than 2 billion tokens, but the clustering code truncates this down to ints.

This patch addresses that, bumps some other sizes that seemed appropriate without too detailed an analysis (so they could be misguided), and keeps most things still using ints. The limit on number of tokens in the corpus gets hit a lot sooner than the limit on word types. E.g. I'm only at 33 million word types in a sample corpus, but 11 billion tokens.

I'm also applying the same patch to generalized-brown.