### PR TITLE
Fix in strdb.cc file for handling large file reads

### DIFF
--- a/basic/strdb.cc
+++ b/basic/strdb.cc
@@ -184,9 +184,9 @@ void read_text(const char *file, int_func *func, StrDB &db, bool read_cached, bo
       }
       if(write_cached) logs("Writing to " << int_file);
 
-      char s[16384];
       char buf[16384]; int buf_i = 0; // Output buffer
-      while(in >> s) { // Read a string
+      for(std::string line; getline( in, line, ' ');) {
+        const char *s = line.c_str();
         int a = db.lookup(s, incorp_new, -1);
         if(func) func(a);
 


### PR DESCRIPTION
strdb.cc terminates with segmentation fault when run on large data files of say 5 GB in size. This commit has a fix for this issue.

```
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff71293ab in __memcpy_ssse3_back () from /lib64/libc.so.6

0x0000000000422558 in read_text (file=<optimized out>, func=0x409ed0 <read_text_process_word(int)>, db=..., read_cached=<optimized out>,
    write_cached=<optimized out>, incorp_new=true) at basic/strdb.cc:189
```